### PR TITLE
fix: update the "poetry" match to work, allow spaces

### DIFF
--- a/lua/cmp-pypi/init.lua
+++ b/lua/cmp-pypi/init.lua
@@ -31,10 +31,12 @@ function source:complete(params, callback)
 
 	local line = params.context.cursor_before_line
 
-	local name, _ = string.match(line, '([^"]+)==([^"=]*)$')
-
+	-- `package == version` for 0 to any number of spaces
+	local name, _ = string.match(line, '([^" ]+) *== *([^"= ]*)$')
+	
 	if not name then
-		name, _ = string.match(line, '^([^= ]+)%s?=%s?"([^"]*)$')
+		-- `package = "version"` for 0 to any number of spaces
+		name, _ = string.match(line, '^([^= ]+) *= *"([^"]*)$')
 
 		if not name then
 			return callback()


### PR DESCRIPTION
This patch makes the following changes:

- Allows expressions like `package == version`.
  - Currently, spaces are not allowed and cause the `curl` call to timeout as it is given a bad URL.
- Fixes the poetry support.
  - I believe the `%s` characters were meant to be spaces.
  - I also modified this to allow any number of spaces.